### PR TITLE
[Orc8r][docker] Fix: Remove the docker-compose down after images build

### DIFF
--- a/orc8r/cloud/docker/build.py
+++ b/orc8r/cloud/docker/build.py
@@ -104,7 +104,6 @@ def main() -> None:
     else:
         d_args = _get_default_file_args(args) + _get_default_build_args(args)
         _run(d_args)
-        _down(args)
 
 
 def _get_modules(mods: Iterable[str]) -> Iterable[MagmaModule]:


### PR DESCRIPTION
## Summary
According to the discussion #5423, and as recommended by @hcgatewood we need to remove the docker-compose down.

## Test Plan
1. Go to magma/orc8r/cloud/docker/
2. Run ./build -a
3. Make sure images built successfully and no warning displayed 
